### PR TITLE
Inline and elide `VNodeData.Builder`

### DIFF
--- a/snabbdom/src/main/scala/snabbdom/VNodeData.scala
+++ b/snabbdom/src/main/scala/snabbdom/VNodeData.scala
@@ -73,52 +73,51 @@ object VNodeData {
 
   def builder = new Builder()
 
-  class Builder() {
-    private val data = empty
+  class Builder(private val data: VNodeData = empty) extends AnyVal {
 
-    def build: VNodeData = data
+    @inline def build: VNodeData = data
 
-    def withKey(key: String): Builder = {
+    @inline def withKey(key: String): Builder = {
       data.key = Some(key)
       this
     }
 
-    def withProps(props: (String, PropValue)*): Builder = {
+    @inline def withProps(props: (String, PropValue)*): Builder = {
       data.props = Some(props.toMap)
       this
     }
 
-    def withAttrs(attrs: (String, AttrValue)*): Builder = {
+    @inline def withAttrs(attrs: (String, AttrValue)*): Builder = {
       data.attrs = Some(attrs.toMap)
       this
     }
 
-    def withClasses(classes: (String, ClassValue)*): Builder = {
+    @inline def withClasses(classes: (String, ClassValue)*): Builder = {
       data.classes = Some(classes.toMap)
       this
     }
 
-    def withStyle(style: (String, StyleValue)*): Builder = {
+    @inline def withStyle(style: (String, StyleValue)*): Builder = {
       data.style = Some(style.toMap)
       this
     }
 
-    def withDataset(dataset: (String, String)*): Builder = {
+    @inline def withDataset(dataset: (String, String)*): Builder = {
       data.dataset = Some(dataset.toMap)
       this
     }
 
-    def withOn(on: (String, EventHandler)*): Builder = {
+    @inline def withOn(on: (String, EventHandler)*): Builder = {
       data.on = Some(on.toMap)
       this
     }
 
-    def withHook(hook: Hooks): Builder = {
+    @inline def withHook(hook: Hooks): Builder = {
       data.hook = Some(hook)
       this
     }
 
-    def withNs(ns: String): Builder = {
+    @inline def withNs(ns: String): Builder = {
       data.ns = Some(ns)
       this
     }


### PR DESCRIPTION
Closes https://github.com/buntec/scala-js-snabbdom/issues/13.

Making the `Builder` an `AnyVal` and inlining all its methods allows it to be completely elided by the Scala.js linker i.e. it no longer appears in the generated JS, all operations are directly on the underlying `VNodeData`.

<details>
<summary>before</summary>

```javascript
'use strict';
import * as $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01 from "./internal-4533885b16a4344ca3051d7b228250be7b5d5e01.js";
import * as $j_internal$002db28b7af69320201d1cf206ebf28373980add1451 from "./internal-b28b7af69320201d1cf206ebf28373980add1451.js";
/** @constructor */
function $c_Lsnabbdom_examples_Example$() {
  /*<skip>*/
}
export { $c_Lsnabbdom_examples_Example$ as $c_Lsnabbdom_examples_Example$ };
$c_Lsnabbdom_examples_Example$.prototype = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$h_O();
$c_Lsnabbdom_examples_Example$.prototype.constructor = $c_Lsnabbdom_examples_Example$;
/** @constructor */
function $h_Lsnabbdom_examples_Example$() {
  /*<skip>*/
}
export { $h_Lsnabbdom_examples_Example$ as $h_Lsnabbdom_examples_Example$ };
$h_Lsnabbdom_examples_Example$.prototype = $c_Lsnabbdom_examples_Example$.prototype;
$c_Lsnabbdom_examples_Example$.prototype.apply__V = (function() {
  var $$x2 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_init$();
  var $$x1 = $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_package$().s_package$__f_Seq;
  var array = [$j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Attributes$().Lsnabbdom_modules_Attributes$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Classes$().Lsnabbdom_modules_Classes$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Props$().Lsnabbdom_modules_Props$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Styles$().Lsnabbdom_modules_Styles$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_EventListeners$().Lsnabbdom_modules_EventListeners$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Dataset$().Lsnabbdom_modules_Dataset$__f_module];
  var patch = $$x2.apply__sci_Seq__s_Option__Lsnabbdom_Patch($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$as_sci_Seq($$x1.apply__sci_Seq__sc_SeqOps(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array))), ($j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_init$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$()));
  var container = document.getElementById("app");
  var $$x11 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var $$x9 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData$Builder();
  var y = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_EventHandler$().fromFunction1__F1__Lsnabbdom_EventHandler(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_AnonFunction1(((x$1$2) => {
    var this$9 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_s_Console$();
    var this$10 = this$9.out__Ljava_io_PrintStream();
    this$10.java$lang$JSConsoleBasedPrintStream$$printString__T__V("foo\n")
  })));
  var array$1 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("click", y)];
  var this$15 = $$x9.withOn__sci_Seq__Lsnabbdom_VNodeData$Builder(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$1));
  var $$x10 = this$15.Lsnabbdom_VNodeData$Builder__f_data;
  var $$x8 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var $$x7 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData$Builder();
  var array$2 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("fontWeight", "bold")];
  var this$22 = $$x7.withStyle__sci_Seq__Lsnabbdom_VNodeData$Builder(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$2));
  var $$x6 = $$x8.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("span", this$22.Lsnabbdom_VNodeData$Builder__f_data, "This is bold");
  var this$23 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_VNode$();
  var $$x5 = this$23.text__T__Lsnabbdom_VNode(" and this is just normal text");
  var $$x4 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var $$x3 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData$Builder();
  var array$3 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("href", "/foo")];
  var this$30 = $$x3.withProps__sci_Seq__Lsnabbdom_VNodeData$Builder(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$3));
  var vnode = $$x11.apply__T__Lsnabbdom_VNodeData__ALsnabbdom_VNode__Lsnabbdom_VNode("div", $$x10, new ($j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$d_Lsnabbdom_VNode.getArrayOf().constr)([$$x6, $$x5, $$x4.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("a", this$30.Lsnabbdom_VNodeData$Builder__f_data, "I'll take you places!")]));
  patch.apply__Lorg_scalajs_dom_Element__Lsnabbdom_VNode__Lsnabbdom_VNode(container, vnode);
  var $$x20 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var $$x18 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData$Builder();
  var y$1 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_EventHandler$().fromFunction1__F1__Lsnabbdom_EventHandler(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_AnonFunction1(((x$2$2) => {
    var this$34 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_s_Console$();
    var this$35 = this$34.out__Ljava_io_PrintStream();
    this$35.java$lang$JSConsoleBasedPrintStream$$printString__T__V("bar\n")
  })));
  var array$4 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("click", y$1)];
  var this$40 = $$x18.withOn__sci_Seq__Lsnabbdom_VNodeData$Builder(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$4));
  var $$x19 = this$40.Lsnabbdom_VNodeData$Builder__f_data;
  var $$x17 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var $$x16 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData$Builder();
  var array$5 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("fontWeight", "normal"), new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("fontStyle", "italic")];
  var this$49 = $$x16.withStyle__sci_Seq__Lsnabbdom_VNodeData$Builder(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$5));
  var $$x15 = $$x17.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("span", this$49.Lsnabbdom_VNodeData$Builder__f_data, "This is now italic type");
  var this$50 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_VNode$();
  var $$x14 = this$50.text__T__Lsnabbdom_VNode(" and this is still just normal text");
  var $$x13 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var $$x12 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData$Builder();
  var array$6 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("href", "/foo")];
  var this$57 = $$x12.withProps__sci_Seq__Lsnabbdom_VNodeData$Builder(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$6));
  var newVnode = $$x20.apply__T__Lsnabbdom_VNodeData__ALsnabbdom_VNode__Lsnabbdom_VNode("div#container.two.classes", $$x19, new ($j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$d_Lsnabbdom_VNode.getArrayOf().constr)([$$x15, $$x14, $$x13.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("a", this$57.Lsnabbdom_VNodeData$Builder__f_data, "I'll take you places!")]));
  patch.apply__Lsnabbdom_VNode__Lsnabbdom_VNode__Lsnabbdom_VNode(vnode, newVnode)
});
var $d_Lsnabbdom_examples_Example$ = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$TypeData().initClass({
  Lsnabbdom_examples_Example$: 0
}, false, "snabbdom.examples.Example$", {
  Lsnabbdom_examples_Example$: 1,
  O: 1
});
export { $d_Lsnabbdom_examples_Example$ as $d_Lsnabbdom_examples_Example$ };
$c_Lsnabbdom_examples_Example$.prototype.$classData = $d_Lsnabbdom_examples_Example$;
var $n_Lsnabbdom_examples_Example$;
function $m_Lsnabbdom_examples_Example$() {
  if ((!$n_Lsnabbdom_examples_Example$)) {
    $n_Lsnabbdom_examples_Example$ = new $c_Lsnabbdom_examples_Example$()
  };
  return $n_Lsnabbdom_examples_Example$
}
export { $m_Lsnabbdom_examples_Example$ as $m_Lsnabbdom_examples_Example$ };
//# sourceMappingURL=snabbdom.examples.Example$.js.map
```
</details>

<details>
<summary>after</summary>

```javascript
'use strict';
import * as $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01 from "./internal-4533885b16a4344ca3051d7b228250be7b5d5e01.js";
import * as $j_internal$002db28b7af69320201d1cf206ebf28373980add1451 from "./internal-b28b7af69320201d1cf206ebf28373980add1451.js";
/** @constructor */
function $c_Lsnabbdom_examples_Example$() {
  /*<skip>*/
}
export { $c_Lsnabbdom_examples_Example$ as $c_Lsnabbdom_examples_Example$ };
$c_Lsnabbdom_examples_Example$.prototype = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$h_O();
$c_Lsnabbdom_examples_Example$.prototype.constructor = $c_Lsnabbdom_examples_Example$;
/** @constructor */
function $h_Lsnabbdom_examples_Example$() {
  /*<skip>*/
}
export { $h_Lsnabbdom_examples_Example$ as $h_Lsnabbdom_examples_Example$ };
$h_Lsnabbdom_examples_Example$.prototype = $c_Lsnabbdom_examples_Example$.prototype;
$c_Lsnabbdom_examples_Example$.prototype.apply__V = (function() {
  var $$x2 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_init$();
  var $$x1 = $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_package$().s_package$__f_Seq;
  var array = [$j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Attributes$().Lsnabbdom_modules_Attributes$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Classes$().Lsnabbdom_modules_Classes$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Props$().Lsnabbdom_modules_Props$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Styles$().Lsnabbdom_modules_Styles$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_EventListeners$().Lsnabbdom_modules_EventListeners$__f_module, $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_modules_Dataset$().Lsnabbdom_modules_Dataset$__f_module];
  var patch = $$x2.apply__sci_Seq__s_Option__Lsnabbdom_Patch($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$as_sci_Seq($$x1.apply__sci_Seq__sc_SeqOps(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array))), ($j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_init$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$()));
  var container = document.getElementById("app");
  var $$x7 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var this$ = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$());
  var y = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_EventHandler$().fromFunction1__F1__Lsnabbdom_EventHandler(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_AnonFunction1(((x$1$2) => {
    var this$11 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_s_Console$();
    var this$12 = this$11.out__Ljava_io_PrintStream();
    this$12.java$lang$JSConsoleBasedPrintStream$$printString__T__V("foo\n")
  })));
  var array$1 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("click", y)];
  var on = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$1);
  this$.Lsnabbdom_VNodeData__f_on = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_s_Some(($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_$less$colon$less$(), $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_sci_Map$().from__sc_IterableOnce__sci_Map(on)));
  var $$x6 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var this$$1 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$());
  var array$2 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("fontWeight", "bold")];
  var style = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$2);
  this$$1.Lsnabbdom_VNodeData__f_style = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_s_Some(($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_$less$colon$less$(), $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_sci_Map$().from__sc_IterableOnce__sci_Map(style)));
  var $$x5 = $$x6.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("span", this$$1, "This is bold");
  var this$31 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_VNode$();
  var $$x4 = this$31.text__T__Lsnabbdom_VNode(" and this is just normal text");
  var $$x3 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var this$$2 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$());
  var array$3 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("href", "/foo")];
  var props = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$3);
  this$$2.Lsnabbdom_VNodeData__f_props = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_s_Some(($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_$less$colon$less$(), $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_sci_Map$().from__sc_IterableOnce__sci_Map(props)));
  var vnode = $$x7.apply__T__Lsnabbdom_VNodeData__ALsnabbdom_VNode__Lsnabbdom_VNode("div", this$, new ($j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$d_Lsnabbdom_VNode.getArrayOf().constr)([$$x5, $$x4, $$x3.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("a", this$$2, "I'll take you places!")]));
  patch.apply__Lorg_scalajs_dom_Element__Lsnabbdom_VNode__Lsnabbdom_VNode(container, vnode);
  var $$x12 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var this$$3 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$());
  var y$1 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_EventHandler$().fromFunction1__F1__Lsnabbdom_EventHandler(new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_AnonFunction1(((x$2$2) => {
    var this$48 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_s_Console$();
    var this$49 = this$48.out__Ljava_io_PrintStream();
    this$49.java$lang$JSConsoleBasedPrintStream$$printString__T__V("bar\n")
  })));
  var array$4 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("click", y$1)];
  var on$1 = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$4);
  this$$3.Lsnabbdom_VNodeData__f_on = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_s_Some(($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_$less$colon$less$(), $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_sci_Map$().from__sc_IterableOnce__sci_Map(on$1)));
  var $$x11 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var this$$4 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$());
  var array$5 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("fontWeight", "normal"), new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("fontStyle", "italic")];
  var style$1 = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$5);
  this$$4.Lsnabbdom_VNodeData__f_style = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_s_Some(($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_$less$colon$less$(), $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_sci_Map$().from__sc_IterableOnce__sci_Map(style$1)));
  var $$x10 = $$x11.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("span", this$$4, "This is now italic type");
  var this$70 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_VNode$();
  var $$x9 = this$70.text__T__Lsnabbdom_VNode(" and this is still just normal text");
  var $$x8 = $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_Lsnabbdom_h$();
  var this$$5 = new $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$c_Lsnabbdom_VNodeData($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$(), $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_None$());
  var array$6 = [new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_T2("href", "/foo")];
  var props$1 = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_sjsr_WrappedVarArgs(array$6);
  this$$5.Lsnabbdom_VNodeData__f_props = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$c_s_Some(($j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$m_s_$less$colon$less$(), $j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$m_sci_Map$().from__sc_IterableOnce__sci_Map(props$1)));
  var newVnode = $$x12.apply__T__Lsnabbdom_VNodeData__ALsnabbdom_VNode__Lsnabbdom_VNode("div#container.two.classes", this$$3, new ($j_internal$002d4533885b16a4344ca3051d7b228250be7b5d5e01.$d_Lsnabbdom_VNode.getArrayOf().constr)([$$x10, $$x9, $$x8.apply__T__Lsnabbdom_VNodeData__T__Lsnabbdom_VNode("a", this$$5, "I'll take you places!")]));
  patch.apply__Lsnabbdom_VNode__Lsnabbdom_VNode__Lsnabbdom_VNode(vnode, newVnode)
});
var $d_Lsnabbdom_examples_Example$ = new $j_internal$002db28b7af69320201d1cf206ebf28373980add1451.$TypeData().initClass({
  Lsnabbdom_examples_Example$: 0
}, false, "snabbdom.examples.Example$", {
  Lsnabbdom_examples_Example$: 1,
  O: 1
});
export { $d_Lsnabbdom_examples_Example$ as $d_Lsnabbdom_examples_Example$ };
$c_Lsnabbdom_examples_Example$.prototype.$classData = $d_Lsnabbdom_examples_Example$;
var $n_Lsnabbdom_examples_Example$;
function $m_Lsnabbdom_examples_Example$() {
  if ((!$n_Lsnabbdom_examples_Example$)) {
    $n_Lsnabbdom_examples_Example$ = new $c_Lsnabbdom_examples_Example$()
  };
  return $n_Lsnabbdom_examples_Example$
}
export { $m_Lsnabbdom_examples_Example$ as $m_Lsnabbdom_examples_Example$ };
//# sourceMappingURL=snabbdom.examples.Example$.js.map
```
</details>
