### PR TITLE
Make `VNodeData` immutable

### DIFF
--- a/examples/src/main/scala/snabbdom/examples/Example.scala
+++ b/examples/src/main/scala/snabbdom/examples/Example.scala
@@ -40,19 +40,17 @@ object Example {
 
     val vnode = h(
       "div",
-      VNodeData.builder
-        .withOn("click" -> ((_: dom.Event) => println("foo")))
-        .build,
+      VNodeData(on = Map("click" -> ((_: dom.Event) => println("foo")))),
       Array[VNode](
         h(
           "span",
-          VNodeData.builder.withStyle("fontWeight" -> "bold").build,
+          VNodeData(style = Map("fontWeight" -> "bold")),
           "This is bold"
         ),
         " and this is just normal text",
         h(
           "a",
-          VNodeData.builder.withProps("href" -> "/foo").build,
+          VNodeData(props = Map("href" -> "/foo")),
           "I'll take you places!"
         )
       )
@@ -62,21 +60,19 @@ object Example {
 
     val newVnode = h(
       "div#container.two.classes",
-      VNodeData.builder
-        .withOn("click" -> ((_: dom.Event) => println("bar")))
-        .build,
+      VNodeData(on = Map("click" -> ((_: dom.Event) => println("bar")))),
       Array[VNode](
         h(
           "span",
-          VNodeData.builder
-            .withStyle("fontWeight" -> "normal", "fontStyle" -> "italic")
-            .build,
+          VNodeData(style =
+            Map("fontWeight" -> "normal", "fontStyle" -> "italic")
+          ),
           "This is now italic type"
         ),
         " and this is still just normal text",
         h(
           "a",
-          VNodeData.builder.withProps("href" -> "/foo").build,
+          VNodeData(props = Map("href" -> "/foo")),
           "I'll take you places!"
         )
       )

--- a/snabbdom/src/main/scala/snabbdom/Listener.scala
+++ b/snabbdom/src/main/scala/snabbdom/Listener.scala
@@ -23,7 +23,7 @@ class Listener(var vnode: VNode) {
 
   def handleEvent(event: dom.Event): Unit = {
     val name = event.`type`
-    vnode.data.map(_.on).flatMap(_.get(name)).foreach { handler =>
+    vnode.data.on.get(name).foreach { handler =>
       handler.cbs.foreach(cb => cb(event, vnode))
     }
   }

--- a/snabbdom/src/main/scala/snabbdom/Listener.scala
+++ b/snabbdom/src/main/scala/snabbdom/Listener.scala
@@ -23,7 +23,7 @@ class Listener(var vnode: VNode) {
 
   def handleEvent(event: dom.Event): Unit = {
     val name = event.`type`
-    vnode.data.flatMap(_.on).flatMap(_.get(name)).foreach { handler =>
+    vnode.data.map(_.on).flatMap(_.get(name)).foreach { handler =>
       handler.cbs.foreach(cb => cb(event, vnode))
     }
   }
@@ -33,6 +33,6 @@ class Listener(var vnode: VNode) {
    * listener and using `handleEvent` directly would result
    * in a new implicit conversion to `js.Function1` every time.
    */
-  val jsFun: js.Function1[dom.Event, Unit] = handleEvent _
+  private[snabbdom] val jsFun: js.Function1[dom.Event, Unit] = handleEvent _
 
 }

--- a/snabbdom/src/main/scala/snabbdom/VNode.scala
+++ b/snabbdom/src/main/scala/snabbdom/VNode.scala
@@ -48,8 +48,8 @@ class VNode private (
       dom.Node
     ], // can't be `dom.Element` unfortunately b/c of fragments
     var text: Option[String],
-    var key: Option[KeyValue],
-    var listener: Option[Listener]
+    val key: Option[KeyValue],
+    private[snabbdom] var listener: Option[Listener]
 )
 
 object VNode {

--- a/snabbdom/src/main/scala/snabbdom/VNode.scala
+++ b/snabbdom/src/main/scala/snabbdom/VNode.scala
@@ -42,7 +42,7 @@ import org.scalajs.dom
 
 class VNode private (
     var sel: Option[String],
-    var data: Option[VNodeData],
+    var data: VNodeData,
     var children: Option[Array[VNode]],
     var elm: Option[
       dom.Node
@@ -50,20 +50,28 @@ class VNode private (
     var text: Option[String],
     val key: Option[KeyValue],
     private[snabbdom] var listener: Option[Listener]
-)
+) {
+
+  override def toString: String =
+    s"sel=$sel, data=$data, text=$text, key=$key, children=$children, elm=$elm"
+
+  private[snabbdom] def isTextNode: Boolean =
+    sel.isEmpty && children.isEmpty && text.isDefined
+
+}
 
 object VNode {
 
   def create(
       sel: Option[String],
-      data: Option[VNodeData],
+      data: VNodeData,
       children: Option[Array[VNode]],
       text: Option[String],
       elm: Option[dom.Node]
-  ) = new VNode(sel, data, children, elm, text, data.flatMap(_.key), None)
+  ) = new VNode(sel, data, children, elm, text, data.key, None)
 
   def text(text: String) =
-    new VNode(None, None, None, None, Some(text), None, None)
+    new VNode(None, VNodeData.empty, None, None, Some(text), None, None)
 
   implicit def fromString(s: String): VNode = text(s)
 

--- a/snabbdom/src/main/scala/snabbdom/VNodeData.scala
+++ b/snabbdom/src/main/scala/snabbdom/VNodeData.scala
@@ -39,18 +39,18 @@
 package snabbdom
 
 case class VNodeData(
-    val props: Map[String, PropValue] = Map.empty,
-    val attrs: Map[String, AttrValue] = Map.empty,
-    val classes: Map[String, ClassValue] = Map.empty,
-    val style: Map[String, StyleValue] = Map.empty,
-    val dataset: Map[String, String] = Map.empty,
-    val on: Map[String, EventHandler] = Map.empty,
-    val hook: Option[Hooks] = None,
-    val key: Option[String] = None,
-    val ns: Option[String] = None, // for SVG
-    val fn: Option[Seq[Any] => VNode] = None, // for thunks
-    val args: Option[Seq[Any]] = None, // for thunks
-    val is: Option[String] = None
+    props: Map[String, PropValue] = Map.empty,
+    attrs: Map[String, AttrValue] = Map.empty,
+    classes: Map[String, ClassValue] = Map.empty,
+    style: Map[String, StyleValue] = Map.empty,
+    dataset: Map[String, String] = Map.empty,
+    on: Map[String, EventHandler] = Map.empty,
+    hook: Option[Hooks] = None,
+    key: Option[String] = None,
+    ns: Option[String] = None, // for SVG
+    fn: Option[Seq[Any] => VNode] = None, // for thunks
+    args: Option[Seq[Any]] = None, // for thunks
+    is: Option[String] = None
 )
 
 object VNodeData {

--- a/snabbdom/src/main/scala/snabbdom/VNodeData.scala
+++ b/snabbdom/src/main/scala/snabbdom/VNodeData.scala
@@ -38,90 +38,23 @@
 
 package snabbdom
 
-class VNodeData(
-    var props: Option[Map[String, PropValue]],
-    var attrs: Option[Map[String, AttrValue]],
-    var classes: Option[Map[String, ClassValue]],
-    var style: Option[Map[String, StyleValue]],
-    var dataset: Option[Map[String, String]],
-    var on: Option[Map[String, EventHandler]],
-    var hook: Option[Hooks],
-    var key: Option[String],
-    var ns: Option[String], // for SVG
-    var fn: Option[Seq[Any] => VNode], // for thunks
-    var args: Option[Seq[Any]], // for thunks
-    var is: Option[String]
+case class VNodeData(
+    val props: Map[String, PropValue] = Map.empty,
+    val attrs: Map[String, AttrValue] = Map.empty,
+    val classes: Map[String, ClassValue] = Map.empty,
+    val style: Map[String, StyleValue] = Map.empty,
+    val dataset: Map[String, String] = Map.empty,
+    val on: Map[String, EventHandler] = Map.empty,
+    val hook: Option[Hooks] = None,
+    val key: Option[String] = None,
+    val ns: Option[String] = None, // for SVG
+    val fn: Option[Seq[Any] => VNode] = None, // for thunks
+    val args: Option[Seq[Any]] = None, // for thunks
+    val is: Option[String] = None
 )
 
 object VNodeData {
 
-  def empty =
-    new VNodeData(
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None
-    )
-
-  def builder = new Builder()
-
-  class Builder(private val data: VNodeData = empty) extends AnyVal {
-
-    @inline def build: VNodeData = data
-
-    @inline def withKey(key: String): Builder = {
-      data.key = Some(key)
-      this
-    }
-
-    @inline def withProps(props: (String, PropValue)*): Builder = {
-      data.props = Some(props.toMap)
-      this
-    }
-
-    @inline def withAttrs(attrs: (String, AttrValue)*): Builder = {
-      data.attrs = Some(attrs.toMap)
-      this
-    }
-
-    @inline def withClasses(classes: (String, ClassValue)*): Builder = {
-      data.classes = Some(classes.toMap)
-      this
-    }
-
-    @inline def withStyle(style: (String, StyleValue)*): Builder = {
-      data.style = Some(style.toMap)
-      this
-    }
-
-    @inline def withDataset(dataset: (String, String)*): Builder = {
-      data.dataset = Some(dataset.toMap)
-      this
-    }
-
-    @inline def withOn(on: (String, EventHandler)*): Builder = {
-      data.on = Some(on.toMap)
-      this
-    }
-
-    @inline def withHook(hook: Hooks): Builder = {
-      data.hook = Some(hook)
-      this
-    }
-
-    @inline def withNs(ns: String): Builder = {
-      data.ns = Some(ns)
-      this
-    }
-
-  }
+  val empty = VNodeData()
 
 }

--- a/snabbdom/src/main/scala/snabbdom/fragment.scala
+++ b/snabbdom/src/main/scala/snabbdom/fragment.scala
@@ -41,7 +41,7 @@ package snabbdom
 object fragment {
 
   def apply(children: Array[VNode]): VNode = {
-    VNode.create(None, None, Some(children), None, None)
+    VNode.create(None, VNodeData.empty, Some(children), None, None)
   }
 
 }

--- a/snabbdom/src/main/scala/snabbdom/h.scala
+++ b/snabbdom/src/main/scala/snabbdom/h.scala
@@ -77,7 +77,7 @@ object h {
     val vnode =
       VNode.create(
         Some(sel),
-        Some(data.getOrElse(VNodeData())),
+        data.getOrElse(VNodeData.empty),
         children,
         text,
         None
@@ -93,9 +93,7 @@ object h {
 
   private[snabbdom] def addNS(vnode: VNode): Unit = {
     val ns = "http://www.w3.org/2000/svg"
-    vnode.data = Some(
-      vnode.data.fold(VNodeData(ns = Some(ns)))(_.copy(ns = Some(ns)))
-    )
+    vnode.data = vnode.data.copy(ns = Some(ns))
     if (vnode.sel.forall(_ != "foreignObject")) {
       vnode.children.foreach(_.map(addNS))
     }

--- a/snabbdom/src/main/scala/snabbdom/h.scala
+++ b/snabbdom/src/main/scala/snabbdom/h.scala
@@ -74,28 +74,30 @@ object h {
       children: Option[Array[VNode]],
       text: Option[String]
   ): VNode = {
-    val data0 = data.getOrElse(VNodeData.empty)
+    val vnode =
+      VNode.create(
+        Some(sel),
+        Some(data.getOrElse(VNodeData())),
+        children,
+        text,
+        None
+      )
     if (
-      sel(0) == 's' && sel(1) == 'v' && sel(2) == 'g' &&
+      sel.startsWith("svg") &&
       (sel.length == 3 || sel(3) == '.' || sel(3) == '#')
     ) {
-      addNS(data0, children, Some(sel))
+      addNS(vnode)
     }
-    VNode.create(Some(sel), Some(data0), children, text, None)
+    vnode
   }
 
-  private[snabbdom] def addNS(
-      data: VNodeData,
-      children: Option[Array[VNode]],
-      sel: Option[String]
-  ): Unit = {
-    data.ns = Some("http://www.w3.org/2000/svg")
-    if (sel.forall(_ != "foreignObject")) {
-      children.foreach {
-        _.map { child =>
-          child.data.foreach(data => addNS(data, child.children, child.sel))
-        }
-      }
+  private[snabbdom] def addNS(vnode: VNode): Unit = {
+    val ns = "http://www.w3.org/2000/svg"
+    vnode.data = Some(
+      vnode.data.fold(VNodeData(ns = Some(ns)))(_.copy(ns = Some(ns)))
+    )
+    if (vnode.sel.forall(_ != "foreignObject")) {
+      vnode.children.foreach(_.map(addNS))
     }
   }
 

--- a/snabbdom/src/main/scala/snabbdom/init.scala
+++ b/snabbdom/src/main/scala/snabbdom/init.scala
@@ -63,6 +63,8 @@ object init {
       domApi: Option[DomApi] = None
   ): Patch = {
 
+    type VNodeQueue = mutable.ArrayBuffer[VNode]
+
     val api = domApi.getOrElse(DomApi.apply)
 
     val cbs: ModuleHooks = modules.foldLeft(ModuleHooks.empty) {

--- a/snabbdom/src/main/scala/snabbdom/modules/Attributes.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Attributes.scala
@@ -93,17 +93,11 @@ object Attributes {
       }
     }
 
-    val oldAttrs = oldVnode.data.map(_.attrs)
-    val attrs = vnode.data.map(_.attrs)
+    val oldAttrs = oldVnode.data.attrs
+    val attrs = vnode.data.attrs
 
-    (oldAttrs, attrs) match {
-      case (Some(oldAttrs), Some(attrs)) if (oldAttrs != attrs) =>
-        update(oldAttrs, attrs)
-      case (Some(oldAttrs), None) =>
-        update(oldAttrs, Map.empty)
-      case (None, Some(attrs)) =>
-        update(Map.empty, attrs)
-      case _ => ()
+    if (oldAttrs != attrs) {
+      update(oldAttrs, attrs)
     }
 
   }

--- a/snabbdom/src/main/scala/snabbdom/modules/Attributes.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Attributes.scala
@@ -93,8 +93,8 @@ object Attributes {
       }
     }
 
-    val oldAttrs = oldVnode.data.flatMap(_.attrs)
-    val attrs = vnode.data.flatMap(_.attrs)
+    val oldAttrs = oldVnode.data.map(_.attrs)
+    val attrs = vnode.data.map(_.attrs)
 
     (oldAttrs, attrs) match {
       case (Some(oldAttrs), Some(attrs)) if (oldAttrs != attrs) =>

--- a/snabbdom/src/main/scala/snabbdom/modules/Classes.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Classes.scala
@@ -78,12 +78,11 @@ object Classes {
       }
     }
 
-    (oldVnode.data.map(_.classes), vnode.data.map(_.classes)) match {
-      case (Some(oldClass), Some(klass)) if oldClass != klass =>
-        update(oldClass, klass)
-      case (Some(oldClass), None) => update(oldClass, Map.empty)
-      case (None, Some(klass))    => update(Map.empty, klass)
-      case _                      => ()
+    val oldClasses = oldVnode.data.classes
+    val classes = vnode.data.classes
+
+    if (oldClasses != classes) {
+      update(oldClasses, classes)
     }
 
   }

--- a/snabbdom/src/main/scala/snabbdom/modules/Classes.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Classes.scala
@@ -78,7 +78,7 @@ object Classes {
       }
     }
 
-    (oldVnode.data.flatMap(_.classes), vnode.data.flatMap(_.classes)) match {
+    (oldVnode.data.map(_.classes), vnode.data.map(_.classes)) match {
       case (Some(oldClass), Some(klass)) if oldClass != klass =>
         update(oldClass, klass)
       case (Some(oldClass), None) => update(oldClass, Map.empty)

--- a/snabbdom/src/main/scala/snabbdom/modules/Dataset.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Dataset.scala
@@ -60,8 +60,8 @@ object Dataset {
   private def updateDataset(oldVnode: VNode, vnode: VNode): Unit = {
 
     val elm = vnode.elm.get.asInstanceOf[dom.HTMLElement]
-    val oldDataset = oldVnode.data.map(_.dataset)
-    val dataset = vnode.data.map(_.dataset)
+    val oldDataset = oldVnode.data.dataset
+    val dataset = vnode.data.dataset
     val d = elm.dataset
 
     def update(
@@ -95,16 +95,10 @@ object Dataset {
           }
         }
       }
-
     }
 
-    (oldDataset, dataset) match {
-      case (Some(oldDataset), Some(dataset)) if oldDataset != dataset =>
-        update(oldDataset, dataset)
-      case (Some(oldDataset), None) =>
-        update(oldDataset, Map.empty)
-      case (None, Some(dataset)) => update(Map.empty, dataset)
-      case _                     => ()
+    if (oldDataset != dataset) {
+      update(oldDataset, dataset)
     }
 
   }

--- a/snabbdom/src/main/scala/snabbdom/modules/Dataset.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Dataset.scala
@@ -60,8 +60,8 @@ object Dataset {
   private def updateDataset(oldVnode: VNode, vnode: VNode): Unit = {
 
     val elm = vnode.elm.get.asInstanceOf[dom.HTMLElement]
-    val oldDataset = oldVnode.data.flatMap(_.dataset)
-    val dataset = vnode.data.flatMap(_.dataset)
+    val oldDataset = oldVnode.data.map(_.dataset)
+    val dataset = vnode.data.map(_.dataset)
     val d = elm.dataset
 
     def update(

--- a/snabbdom/src/main/scala/snabbdom/modules/EventListeners.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/EventListeners.scala
@@ -67,10 +67,10 @@ object EventListeners {
       vnode: Option[VNode]
   ): Unit = {
 
-    val oldOn = oldVnode.data.flatMap(_.on)
+    val oldOn = oldVnode.data.map(_.on)
     val oldListener = oldVnode.listener
     val oldElm = oldVnode.elm.map(_.asInstanceOf[dom.Element])
-    val on = vnode.flatMap(_.data).flatMap(_.on)
+    val on = vnode.flatMap(_.data).map(_.on)
     val elm = vnode.flatMap(_.elm).map(_.asInstanceOf[dom.Element])
 
     (oldOn, oldListener, on) match {

--- a/snabbdom/src/main/scala/snabbdom/modules/EventListeners.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/EventListeners.scala
@@ -67,60 +67,52 @@ object EventListeners {
       vnode: Option[VNode]
   ): Unit = {
 
-    val oldOn = oldVnode.data.map(_.on)
+    val oldOn = oldVnode.data.on
     val oldListener = oldVnode.listener
     val oldElm = oldVnode.elm.map(_.asInstanceOf[dom.Element])
-    val on = vnode.flatMap(_.data).map(_.on)
+    val on = vnode.map(_.data.on).getOrElse(Map.empty)
     val elm = vnode.flatMap(_.elm).map(_.asInstanceOf[dom.Element])
 
-    (oldOn, oldListener, on) match {
-      case (None, _, None)                           => ()
-      case (Some(_), None, None)                     => ()
-      case (Some(oldOn), _, Some(on)) if oldOn == on => ()
-      case (Some(oldOn), Some(oldListener), Some(on)) =>
-        oldOn.foreach { case (name, _) =>
-          if (on.get(name).isEmpty) {
-            oldElm.foreach(
-              _.removeEventListener(name, oldListener.jsFun, false)
-            )
+    if (oldOn != on) {
+
+      if (oldOn.nonEmpty && oldListener.isDefined) {
+        val ol = oldListener.get
+        if (on.isEmpty) {
+          oldOn.foreach { case (name, _) =>
+            oldElm.foreach { elm =>
+              elm.removeEventListener(name, ol.jsFun, false)
+            }
+          }
+        } else {
+          oldOn.foreach { case (name, _) =>
+            if (on.get(name).isEmpty) {
+              oldElm.foreach(
+                _.removeEventListener(name, ol.jsFun, false)
+              )
+            }
           }
         }
+      }
 
-        // repurpose old listener
-        val listener = oldListener
+      if (on.nonEmpty) {
+
+        val listener = oldListener.getOrElse(createListener(vnode.get))
         listener.vnode = vnode.get
         vnode.foreach(_.listener = Some(listener))
 
-        on.foreach { case (name, _) =>
-          if (!oldOn.contains(name)) {
+        if (oldOn.isEmpty) {
+          on.foreach { case (name, _) =>
             elm.foreach(_.addEventListener(name, listener.jsFun, false))
           }
-        }
-
-      case (Some(oldOn), None, Some(on)) =>
-        val listener = createListener(vnode.get)
-        vnode.foreach(_.listener = Some(listener))
-
-        on.foreach { case (name, _) =>
-          if (!oldOn.contains(name)) {
-            elm.foreach(_.addEventListener(name, listener.jsFun, false))
+        } else {
+          on.foreach { case (name, _) =>
+            if (!oldOn.contains(name)) {
+              elm.foreach(_.addEventListener(name, listener.jsFun, false))
+            }
           }
         }
 
-      case (Some(oldOn), Some(oldListener), None) =>
-        oldOn.foreach { case (name, _) =>
-          oldElm.foreach { elm =>
-            elm.removeEventListener(name, oldListener.jsFun, false)
-          }
-        }
-
-      case (None, _, Some(on)) =>
-        val listener = oldVnode.listener.getOrElse(createListener(vnode.get))
-        listener.vnode = vnode.get
-        vnode.foreach(_.listener = Some(listener))
-        on.foreach { case (name, _) =>
-          elm.foreach(_.addEventListener(name, listener.jsFun, false))
-        }
+      }
 
     }
 

--- a/snabbdom/src/main/scala/snabbdom/modules/Props.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Props.scala
@@ -56,8 +56,8 @@ object Props {
 
   private def updateProps(oldVnode: VNode, vnode: VNode): Unit = {
     val elm = vnode.elm.get
-    val oldProps = oldVnode.data.map(_.props)
-    val props = vnode.data.map(_.props)
+    val oldProps = oldVnode.data.props
+    val props = vnode.data.props
 
     def update(
         oldProps: Map[String, PropValue],
@@ -73,11 +73,8 @@ object Props {
       }
     }
 
-    (oldProps, props) match {
-      case (Some(oldProps), Some(props)) if oldProps != props =>
-        update(oldProps, props)
-      case (None, Some(props)) => update(Map.empty, props)
-      case _                   => ()
+    if (oldProps != props) {
+      update(oldProps, props) // TODO: remove old props
     }
 
   }

--- a/snabbdom/src/main/scala/snabbdom/modules/Props.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Props.scala
@@ -56,8 +56,8 @@ object Props {
 
   private def updateProps(oldVnode: VNode, vnode: VNode): Unit = {
     val elm = vnode.elm.get
-    val oldProps = oldVnode.data.flatMap(_.props)
-    val props = vnode.data.flatMap(_.props)
+    val oldProps = oldVnode.data.map(_.props)
+    val props = vnode.data.map(_.props)
 
     def update(
         oldProps: Map[String, PropValue],

--- a/snabbdom/src/main/scala/snabbdom/modules/Styles.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Styles.scala
@@ -100,7 +100,7 @@ object Styles {
 
     }
 
-    (oldVnode.data.flatMap(_.style), vnode.data.flatMap(_.style)) match {
+    (oldVnode.data.map(_.style), vnode.data.map(_.style)) match {
       case (Some(oldStyle), Some(style)) if oldStyle != style =>
         update(oldStyle, style)
       case (Some(oldStyle), None) => update(oldStyle, Map.empty)

--- a/snabbdom/src/main/scala/snabbdom/modules/Styles.scala
+++ b/snabbdom/src/main/scala/snabbdom/modules/Styles.scala
@@ -100,12 +100,11 @@ object Styles {
 
     }
 
-    (oldVnode.data.map(_.style), vnode.data.map(_.style)) match {
-      case (Some(oldStyle), Some(style)) if oldStyle != style =>
-        update(oldStyle, style)
-      case (Some(oldStyle), None) => update(oldStyle, Map.empty)
-      case (None, Some(style))    => update(Map.empty, style)
-      case _                      => ()
+    val oldStyle = oldVnode.data.style
+    val style = vnode.data.style
+
+    if (oldStyle != style) {
+      update(oldStyle, style)
     }
 
   }

--- a/snabbdom/src/main/scala/snabbdom/package.scala
+++ b/snabbdom/src/main/scala/snabbdom/package.scala
@@ -36,11 +36,7 @@
  * IN THE SOFTWARE.
  */
 
-import scala.collection.mutable
-
 package object snabbdom {
-
-  type VNodeQueue = mutable.ArrayBuffer[VNode]
 
   type PropValue = Any
   type AttrValue = Any // JS snabbdom uses string | number | boolean

--- a/snabbdom/src/main/scala/snabbdom/thunk.scala
+++ b/snabbdom/src/main/scala/snabbdom/thunk.scala
@@ -70,7 +70,7 @@ object thunk {
   }
 
   private def init0(thunk: VNode): Unit = {
-    val data = thunk.data.get
+    val data = thunk.data
     val fn = data.fn.get
     val args = data.args.get
     copyToThunk(fn(args), thunk)
@@ -79,10 +79,10 @@ object thunk {
   private def prepatch0(oldVnode: VNode, thunk: VNode): Unit = {
     val old = oldVnode.data
     val cur = thunk.data
-    val oldArgs = old.flatMap(_.args)
-    val args = cur.flatMap(_.args)
-    val oldFn = old.flatMap(_.fn)
-    val curFn = cur.flatMap(_.fn)
+    val oldArgs = old.args
+    val args = cur.args
+    val oldFn = old.fn
+    val curFn = cur.fn
     if (oldFn != curFn || oldArgs != args) {
       copyToThunk(curFn.get(args.get), thunk)
     } else {
@@ -91,13 +91,10 @@ object thunk {
   }
 
   private def copyToThunk(vnode: VNode, thunk: VNode): Unit = {
-    val ns = thunk.data.flatMap(_.ns)
-    val fn = thunk.data.flatMap(_.fn)
-    val args = thunk.data.flatMap(_.args)
-    val data0 = vnode.data.fold(VNodeData(fn = fn, args = args))(
-      _.copy(fn = fn, args = args)
-    )
-    vnode.data = Some(data0)
+    val ns = thunk.data.ns
+    val fn = thunk.data.fn
+    val args = thunk.data.args
+    vnode.data = vnode.data.copy(fn = fn, args = args)
     thunk.data = vnode.data
     thunk.children = vnode.children
     thunk.text = vnode.text

--- a/snabbdom/src/main/scala/snabbdom/toVNode.scala
+++ b/snabbdom/src/main/scala/snabbdom/toVNode.scala
@@ -81,7 +81,7 @@ object toVNode {
 
       val vnode = VNode.create(
         Some(sel),
-        Some(data),
+        data,
         Some(children.toArray),
         None,
         Some(node)
@@ -99,12 +99,12 @@ object toVNode {
 
     } else if (api.isText(node)) {
       val text = api.getTextContent(node).getOrElse("")
-      VNode.create(None, None, None, Some(text), Some(node))
+      VNode.create(None, VNodeData.empty, None, Some(text), Some(node))
     } else if (api.isComment(node)) {
       val text = api.getTextContent(node).getOrElse("")
-      VNode.create(Some("!"), None, None, Some(text), Some(node))
+      VNode.create(Some("!"), VNodeData.empty, None, Some(text), Some(node))
     } else {
-      VNode.create(Some(""), None, None, None, Some(node))
+      VNode.create(Some(""), VNodeData.empty, None, None, Some(node))
     }
 
   }

--- a/snabbdom/src/main/scala/snabbdom/toVNode.scala
+++ b/snabbdom/src/main/scala/snabbdom/toVNode.scala
@@ -56,7 +56,6 @@ object toVNode {
       val sel = api.tagName(elm).toLowerCase + id + c
       val attrs = mutable.Map.empty[String, String]
       val datasets = mutable.Map.empty[String, String]
-      val data = VNodeData.empty
 
       val children = new mutable.ArrayBuffer[VNode]
       val elmAttrs = elm.attributes
@@ -74,24 +73,29 @@ object toVNode {
         children.append(toVNode(childNode, domApi))
       }
 
-      if (attrs.nonEmpty) { data.attrs = Some(attrs.toMap) }
-      if (datasets.nonEmpty) { data.dataset = Some(datasets.toMap) }
+      val data =
+        VNodeData(
+          attrs = if (attrs.nonEmpty) attrs.toMap else Map.empty,
+          dataset = if (datasets.nonEmpty) datasets.toMap else Map.empty
+        )
 
-      if (
-        sel.startsWith("svg") && (sel.length == 3 || sel(3) == '.' || sel(
-          3
-        ) == '#')
-      ) {
-        h.addNS(data, Some(children.toArray), Some(sel))
-      }
-
-      VNode.create(
+      val vnode = VNode.create(
         Some(sel),
         Some(data),
         Some(children.toArray),
         None,
         Some(node)
       )
+
+      if (
+        sel.startsWith("svg") && (sel.length == 3 || sel(3) == '.' || sel(
+          3
+        ) == '#')
+      ) {
+        h.addNS(vnode)
+      }
+
+      vnode
 
     } else if (api.isText(node)) {
       val text = api.getTextContent(node).getOrElse("")

--- a/snabbdom/src/test/scala/snabbdom/AttributesSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/AttributesSuite.scala
@@ -56,14 +56,14 @@ class AttributesSuite extends BaseSuite {
     vnode0.test("have their provided values") { vnode0 =>
       val vnode1 = h(
         "div",
-        VNodeData.builder
-          .withAttrs(
+        VNodeData(attrs =
+          Map(
             "href" -> "/foo",
             "minlength" -> 1,
             "selected" -> true,
             "disabled" -> false
           )
-          .build
+        )
       )
       val elm = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.Element]
       assertEquals(elm.getAttribute("href"), "/foo")
@@ -74,9 +74,9 @@ class AttributesSuite extends BaseSuite {
     }
 
     vnode0.test("can be memoized") { vnode0 =>
-      val cachedAttrs = VNodeData.builder
-        .withAttrs("href" -> "/foo", "minlength" -> 1, "selected" -> true)
-        .build
+      val cachedAttrs = VNodeData(
+        attrs = Map("href" -> "/foo", "minlength" -> 1, "selected" -> true)
+      )
       val vnode1 = h("div", cachedAttrs)
       val vnode2 = h("div", cachedAttrs)
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.Element]
@@ -94,14 +94,14 @@ class AttributesSuite extends BaseSuite {
       vnode0 =>
         val vnode1 = h(
           "div",
-          VNodeData.builder
-            .withAttrs(
+          VNodeData(attrs =
+            Map(
               "href" -> None,
               "minlength" -> 0,
               "value" -> "",
               "title" -> "undefined"
             )
-            .build
+          )
         )
         val elm = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.Element]
         assertEquals(elm.hasAttribute("href"), true)
@@ -112,7 +112,7 @@ class AttributesSuite extends BaseSuite {
 
     vnode0.test("are set correctly when namespaced") { vnode0 =>
       val vnode1 =
-        h("div", VNodeData.builder.withAttrs("xlink:href" -> "#foo").build)
+        h("div", VNodeData(attrs = Map("xlink:href" -> "#foo")))
       val elm = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.Element]
       assertEquals(
         elm.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
@@ -127,7 +127,7 @@ class AttributesSuite extends BaseSuite {
       val vnode0 = elm
       val vnode1 = h(
         "div#myId.myClass",
-        VNodeData.builder.withAttrs().build,
+        VNodeData(),
         Array[VNode]("Hello")
       )
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
@@ -145,13 +145,13 @@ class AttributesSuite extends BaseSuite {
       vnode0 =>
         val vnode1 = h(
           "div",
-          VNodeData.builder
-            .withAttrs(
+          VNodeData(attrs =
+            Map(
               "required" -> true,
               "readonly" -> 1,
               "noresize" -> "truthy"
             )
-            .build
+          )
         )
         val elm = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
         assertEquals(elm.hasAttribute("required"), true)
@@ -163,8 +163,7 @@ class AttributesSuite extends BaseSuite {
     }
 
     vnode0.test("is omitted if the value is false") { vnode0 =>
-      val vnode1 =
-        h("div", VNodeData.builder.withAttrs("required" -> false).build)
+      val vnode1 = h("div", VNodeData(attrs = Map("required" -> false)))
       val elm = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
       assertEquals(elm.hasAttribute("required"), false)
       assertEquals(elm.getAttribute("required"), null)
@@ -174,7 +173,7 @@ class AttributesSuite extends BaseSuite {
       val vnode1 =
         h(
           "div",
-          VNodeData.builder.withAttrs("readonly" -> 0, "noresize" -> "").build
+          VNodeData(attrs = Map("readonly" -> 0, "noresize" -> ""))
         )
       val elm = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
       assertEquals(elm.hasAttribute("readonly"), true)
@@ -189,13 +188,12 @@ class AttributesSuite extends BaseSuite {
     vnode0.test(
       "is not considered as a boolean attribute and shouldn't be omitted"
     ) { vnode0 =>
-      val vnode1 =
-        h("div", VNodeData.builder.withAttrs("constructor" -> true).build)
+      val vnode1 = h("div", VNodeData(attrs = Map("constructor" -> true)))
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.Element]
       assertEquals(elm1.hasAttribute("constructor"), true)
       assertEquals(elm1.getAttribute("constructor"), "")
       val vnode2 =
-        h("div", VNodeData.builder.withAttrs("constructor" -> false).build)
+        h("div", VNodeData(attrs = Map("constructor" -> false)))
       val elm2 = patch(vnode1, vnode2).elm.get.asInstanceOf[dom.Element]
       assertEquals(elm2.hasAttribute("constructor"), false)
 

--- a/snabbdom/src/test/scala/snabbdom/DatasetSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/DatasetSuite.scala
@@ -55,7 +55,7 @@ class DatasetSuite extends BaseSuite {
   vnode0.test("is set on initial element creation") { vnode0 =>
     val elm = patch(
       vnode0,
-      h("div", VNodeData.builder.withDataset("foo" -> "foo").build)
+      h("div", VNodeData(dataset = Map("foo" -> "foo")))
     ).elm.get.asInstanceOf[dom.HTMLElement]
     assertEquals(elm.dataset("foo"), "foo")
   }

--- a/snabbdom/src/test/scala/snabbdom/EventListenersSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/EventListenersSuite.scala
@@ -63,7 +63,7 @@ class EventListenersSuite extends BaseSuite {
     val clicked = EventHandler((ev: dom.Event) => result += ev)
     val vnode = h(
       "div",
-      VNodeData.builder.withOn("click" -> clicked).build,
+      VNodeData(on = Map("click" -> clicked)),
       Array(h("a", "Click my parent"))
     )
     val elm = patch(vnode0, vnode).elm.get
@@ -76,14 +76,14 @@ class EventListenersSuite extends BaseSuite {
     val result = List.newBuilder[Int]
     val vnode1 = h(
       "div",
-      VNodeData.builder
-        .withOn("click" -> EventHandler((_: dom.Event) => result += 1))
-        .build,
+      VNodeData(on =
+        Map("click" -> EventHandler((_: dom.Event) => result += 1))
+      ),
       Array(h("a", "Click my parent"))
     )
     val vnode2 = h(
       "div",
-      VNodeData.builder.withOn("click" -> EventHandler(_ => result += 2)).build,
+      VNodeData(on = Map("click" -> EventHandler(_ => result += 2))),
       Array(h("a", "Click my parent"))
     )
     val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
@@ -102,13 +102,13 @@ class EventListenersSuite extends BaseSuite {
     }
     val vnode1 = h(
       "div",
-      VNodeData.builder.withOn("click" -> clicked).build,
+      VNodeData(on = Map("click" -> clicked)),
       Array(h("a", "Click my parent"))
     )
     val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
     elm1.click()
     assertEquals(result.length, 1)
-    val vnode2 = h("div", VNodeData.empty, Array(h("a", "Click my parent")))
+    val vnode2 = h("div", VNodeData(), Array(h("a", "Click my parent")))
     val elm2 = patch(vnode1, vnode2).elm.get.asInstanceOf[dom.HTMLElement]
     elm2.click()
     assertEquals(result.length, 1)
@@ -125,9 +125,9 @@ class EventListenersSuite extends BaseSuite {
 
       val vnode1 = h(
         "div",
-        VNodeData.builder
-          .withOn("click" -> EventHandler.usingVNode(clicked, clicked, clicked))
-          .build,
+        VNodeData(on =
+          Map("click" -> EventHandler.usingVNode(clicked, clicked, clicked))
+        ),
         Array(h("a", "Click my parent"))
       )
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
@@ -135,9 +135,9 @@ class EventListenersSuite extends BaseSuite {
       assertEquals(called, 3)
       val vnode2 = h(
         "div",
-        VNodeData.builder
-          .withOn("click" -> EventHandler.usingVNode(clicked, clicked))
-          .build,
+        VNodeData(on =
+          Map("click" -> EventHandler.usingVNode(clicked, clicked))
+        ),
         Array(h("a", "Click my parent"))
       )
       val elm2 = patch(vnode1, vnode2).elm.get.asInstanceOf[dom.HTMLElement]
@@ -153,7 +153,7 @@ class EventListenersSuite extends BaseSuite {
     }
     val vnode1 = h(
       "div",
-      VNodeData.builder.withOn("click" -> clicked).build,
+      VNodeData(on = Map("click" -> clicked)),
       Array(h("a", "Click my parent"))
     )
     val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
@@ -170,11 +170,11 @@ class EventListenersSuite extends BaseSuite {
     }
     val vnode1 = h(
       "div",
-      VNodeData.builder.withOn("click" -> clicked).build,
+      VNodeData(on = Map("click" -> clicked)),
       Array(
         h(
           "a",
-          VNodeData.builder.withOn("click" -> clicked).build,
+          VNodeData(on = Map("click" -> clicked)),
           "Click my parent"
         )
       )

--- a/snabbdom/src/test/scala/snabbdom/SnabbdomSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/SnabbdomSuite.scala
@@ -500,7 +500,7 @@ class SnabbdomSuite extends BaseSuite {
       val prevElm = dom.document.createDocumentFragment()
       val nextVNode = VNode.create(
         Some(""),
-        None,
+        VNodeData.empty,
         Some(Array(h("div#id.class", Array(h("span", "Hi"))))),
         None,
         Some(prevElm)
@@ -607,14 +607,14 @@ class SnabbdomSuite extends BaseSuite {
       val onlyAttrs = dom.document.createElement("div")
       onlyAttrs.setAttribute("foo", "bar")
       assertEquals(
-        toVNode(onlyAttrs).data.map(_.attrs).flatMap(_.get("foo")),
+        toVNode(onlyAttrs).data.attrs.get("foo"),
         Some("bar")
       )
 
       val onlyDatasets = dom.document.createElement("div")
       onlyDatasets.setAttribute("data-foo", "bar")
       assertEquals(
-        toVNode(onlyDatasets).data.map(_.dataset).flatMap(_.get("foo")),
+        toVNode(onlyDatasets).data.dataset.get("foo"),
         Some("bar")
       )
 
@@ -622,7 +622,7 @@ class SnabbdomSuite extends BaseSuite {
         dom.document.createElement("div").asInstanceOf[dom.HTMLElement]
       onlyDatasets2.dataset("foo") = "bar"
       assertEquals(
-        toVNode(onlyDatasets).data.map(_.dataset).flatMap(_.get("foo")),
+        toVNode(onlyDatasets).data.dataset.get("foo"),
         Some("bar")
       )
 
@@ -631,7 +631,7 @@ class SnabbdomSuite extends BaseSuite {
       bothAttrsAndDatasets.setAttribute("foo", "bar")
       bothAttrsAndDatasets.setAttribute("data-foo", "bar")
       bothAttrsAndDatasets.dataset("again") = "again"
-      val data = toVNode(bothAttrsAndDatasets).data.get
+      val data = toVNode(bothAttrsAndDatasets).data
       assertEquals(data.attrs.get("foo"), Some("bar"))
       assertEquals(data.dataset.get("foo"), Some("bar"))
       assertEquals(data.dataset.get("again"), Some("again"))

--- a/snabbdom/src/test/scala/snabbdom/SnabbdomSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/SnabbdomSuite.scala
@@ -46,9 +46,9 @@ import scala.collection.mutable.ListBuffer
 
 class SnabbdomSuite extends BaseSuite {
 
-  def spanNum(s: String) = h("span", VNodeData.empty, s)
+  def spanNum(s: String) = h("span", VNodeData(), s)
   def spanNum(i: Int) =
-    h("span", VNodeData.builder.withKey(i.toString).build, i.toString)
+    h("span", VNodeData(key = Some(i.toString)), i.toString)
 
   val vnode0 = FunFixture[dom.Element](
     setup = { _ =>
@@ -88,7 +88,7 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     test("can create vnode with props and one child vnode") {
-      val vnode = h("div", VNodeData.empty, h("span#hello"))
+      val vnode = h("div", VNodeData(), h("span#hello"))
       assertEquals(vnode.sel, Some("div"))
       val children = vnode.children
       assertEquals(children.flatMap(_(0).sel), Some("span#hello"))
@@ -106,7 +106,7 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     test("can create vnode with props and text content in string") {
-      val vnode = h("a", VNodeData.empty, "I am a string")
+      val vnode = h("a", VNodeData(), "I am a string")
       assertEquals(vnode.text, Some("I am a string"))
     }
 
@@ -116,7 +116,7 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     test("can create vnode with props and String obj content") {
-      val vnode = h("a", VNodeData.empty, new String("b"))
+      val vnode = h("a", VNodeData(), new String("b"))
       assertEquals(vnode.text, Some("b"))
     }
 
@@ -166,7 +166,7 @@ class SnabbdomSuite extends BaseSuite {
       val SVGNamespace = "http://www.w3.org/2000/svg";
       val XHTMLNamespace = "http://www.w3.org/1999/xhtml";
 
-      val data = VNodeData.builder.withNs(SVGNamespace).build
+      val data = VNodeData(ns = Some(SVGNamespace))
 
       val elm1 = patch(vnode0, h("div", Array(h("div", data)))).elm.get
       assertEquals(elm1.firstChild.namespaceURI, SVGNamespace)
@@ -209,14 +209,14 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     vnode0.test("receives classes in class property") { vnode0 =>
-      val data = VNodeData.builder
-        .withClasses(
+      val data = VNodeData(classes =
+        Map(
           "am" -> true,
           "a" -> true,
           "class" -> true,
           "not" -> false
         )
-        .build
+      )
       val elm = patch(vnode0, h("i", data)).elm.get
       assert(elm.asInstanceOf[dom.Element].classList.contains("am"))
       assert(elm.asInstanceOf[dom.Element].classList.contains("a"))
@@ -235,14 +235,14 @@ class SnabbdomSuite extends BaseSuite {
 
     vnode0.test("receives classes in class property when namespaced") {
       vnode0 =>
-        val data = VNodeData.builder
-          .withClasses(
+        val data = VNodeData(classes =
+          Map(
             "am" -> true,
             "a" -> true,
             "class" -> true,
             "not" -> false
           )
-          .build
+        )
         val elm = patch(vnode0, h("svg", Array(h("g", data)))).elm.get
         assert(
           elm.firstChild.asInstanceOf[dom.Element].classList.contains("am")
@@ -257,7 +257,7 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     vnode0.test("handles classes from both selector and property") { vnode0 =>
-      val data = VNodeData.builder.withClasses("classes" -> true).build
+      val data = VNodeData(classes = Map("classes" -> true))
       val elm = patch(vnode0, h("div", Array(h("i.has", data)))).elm.get
       assert(elm.firstChild.asInstanceOf[dom.Element].classList.contains("has"))
       assert(
@@ -286,7 +286,7 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     vnode0.test("can create elements with props") { vnode0 =>
-      val data = VNodeData.builder.withProps("src" -> "http://localhost/").build
+      val data = VNodeData(props = Map("src" -> "http://localhost/"))
       val elm = patch(vnode0, h("a", data)).elm.get
       assertEquals(
         elm.asInstanceOf[js.Dictionary[String]]("src"),
@@ -337,15 +337,11 @@ class SnabbdomSuite extends BaseSuite {
     vnode0.test("changes the elements classes") { vnode0 =>
       val vnode1 = h(
         "i",
-        VNodeData.builder
-          .withClasses("i" -> true, "am" -> true, "horse" -> true)
-          .build
+        VNodeData(classes = Map("i" -> true, "am" -> true, "horse" -> true))
       )
       val vnode2 = h(
         "i",
-        VNodeData.builder
-          .withClasses("i" -> true, "am" -> true, "horse" -> false)
-          .build
+        VNodeData(classes = Map("i" -> true, "am" -> true, "horse" -> false))
       )
       patch(vnode0, vnode1)
       val elm = patch(vnode1, vnode2).elm.get
@@ -360,9 +356,7 @@ class SnabbdomSuite extends BaseSuite {
 
     vnode0.test("preserves memoized classes") { vnode0 =>
       val cachedClasses =
-        VNodeData.builder
-          .withClasses("i" -> true, "am" -> true, "horse" -> false)
-          .build
+        VNodeData(classes = Map("i" -> true, "am" -> true, "horse" -> false))
       val vnode1 = h("i", cachedClasses)
       val vnode2 = h("i", cachedClasses)
       val elm = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.Element]
@@ -378,15 +372,11 @@ class SnabbdomSuite extends BaseSuite {
     vnode0.test("removes missing classes") { vnode0 =>
       val vnode1 = h(
         "i",
-        VNodeData.builder
-          .withClasses("i" -> true, "am" -> true, "horse" -> true)
-          .build
+        VNodeData(classes = Map("i" -> true, "am" -> true, "horse" -> true))
       )
       val vnode2 = h(
         "i",
-        VNodeData.builder
-          .withClasses("i" -> true, "am" -> true)
-          .build
+        VNodeData(classes = Map("i" -> true, "am" -> true))
       )
       patch(vnode0, vnode1)
       val elm = patch(vnode1, vnode2).elm.get.asInstanceOf[dom.Element]
@@ -397,9 +387,9 @@ class SnabbdomSuite extends BaseSuite {
 
     vnode0.test("changes an elements props") { vnode0 =>
       val vnode1 =
-        h("a", VNodeData.builder.withProps("src" -> "http://other/").build)
+        h("a", VNodeData(props = Map("src" -> "http://other/")))
       val vnode2 =
-        h("a", VNodeData.builder.withProps("src" -> "http://localhost/").build)
+        h("a", VNodeData(props = Map("src" -> "http://localhost/")))
       patch(vnode0, vnode1)
       val elm =
         patch(vnode1, vnode2).elm.get.asInstanceOf[js.Dictionary[String]]
@@ -407,8 +397,7 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     vnode0.test("preserves memoized props") { vnode0 =>
-      val cachedProps =
-        VNodeData.builder.withProps("src" -> "http://other/").build
+      val cachedProps = VNodeData(props = Map("src" -> "http://other/"))
       val vnode1 = h("a", cachedProps)
       val vnode2 = h("a", cachedProps)
       val elm = patch(vnode0, vnode1).elm.get
@@ -425,14 +414,14 @@ class SnabbdomSuite extends BaseSuite {
 
     vnode0.test("can set prop value to empty string") { vnode0 =>
       val vnode1 =
-        h("p", VNodeData.builder.withProps("textContent" -> "foo").build)
+        h("p", VNodeData(props = Map("textContent" -> "foo")))
       val elm = patch(vnode0, vnode1).elm.get
       assertEquals(
         elm.asInstanceOf[dom.HTMLParagraphElement].textContent,
         "foo"
       )
       val vnode2 =
-        h("p", VNodeData.builder.withProps("textContent" -> "").build)
+        h("p", VNodeData(props = Map("textContent" -> "")))
       val elm2 = patch(vnode1, vnode2).elm.get
       assertEquals(elm2.asInstanceOf[dom.HTMLParagraphElement].textContent, "")
 
@@ -441,7 +430,7 @@ class SnabbdomSuite extends BaseSuite {
     // TODO: This appears to be a bug in the orignal: https://github.com/snabbdom/snabbdom/pull/1019
     vnode0.test("removes custom props".ignore) { vnode0 =>
       val vnode1 =
-        h("a", VNodeData.builder.withProps("src" -> "http://other/").build)
+        h("a", VNodeData(props = Map("src" -> "http://other/")))
       val vnode2 = h("a")
       patch(vnode0, vnode1)
       val elm = patch(vnode1, vnode2).elm.get
@@ -450,10 +439,7 @@ class SnabbdomSuite extends BaseSuite {
 
     vnode0.test("cannot remove native props") { vnode0 =>
       val vnode1 =
-        h(
-          "a",
-          VNodeData.builder.withProps("href" -> "http://example.com/").build
-        )
+        h("a", VNodeData(props = Map("href" -> "http://example.com/")))
       val vnode2 = h("a")
       val elm1 = patch(vnode0, vnode1).elm.get
       assert(elm1.isInstanceOf[dom.HTMLAnchorElement])
@@ -471,7 +457,7 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     vnode0.test("does not delete custom props") { vnode0 =>
-      val vnode1 = h("p", VNodeData.builder.withProps("a" -> "foo").build)
+      val vnode1 = h("p", VNodeData(props = Map("a" -> "foo")))
       val vnode2 = h("p")
       val elm = patch(vnode0, vnode1).elm.get
       assert(elm.isInstanceOf[dom.HTMLParagraphElement])
@@ -621,14 +607,14 @@ class SnabbdomSuite extends BaseSuite {
       val onlyAttrs = dom.document.createElement("div")
       onlyAttrs.setAttribute("foo", "bar")
       assertEquals(
-        toVNode(onlyAttrs).data.flatMap(_.attrs).flatMap(_.get("foo")),
+        toVNode(onlyAttrs).data.map(_.attrs).flatMap(_.get("foo")),
         Some("bar")
       )
 
       val onlyDatasets = dom.document.createElement("div")
       onlyDatasets.setAttribute("data-foo", "bar")
       assertEquals(
-        toVNode(onlyDatasets).data.flatMap(_.dataset).flatMap(_.get("foo")),
+        toVNode(onlyDatasets).data.map(_.dataset).flatMap(_.get("foo")),
         Some("bar")
       )
 
@@ -636,7 +622,7 @@ class SnabbdomSuite extends BaseSuite {
         dom.document.createElement("div").asInstanceOf[dom.HTMLElement]
       onlyDatasets2.dataset("foo") = "bar"
       assertEquals(
-        toVNode(onlyDatasets).data.flatMap(_.dataset).flatMap(_.get("foo")),
+        toVNode(onlyDatasets).data.map(_.dataset).flatMap(_.get("foo")),
         Some("bar")
       )
 
@@ -646,9 +632,9 @@ class SnabbdomSuite extends BaseSuite {
       bothAttrsAndDatasets.setAttribute("data-foo", "bar")
       bothAttrsAndDatasets.dataset("again") = "again"
       val data = toVNode(bothAttrsAndDatasets).data.get
-      assertEquals(data.attrs.flatMap(_.get("foo")), Some("bar"))
-      assertEquals(data.dataset.flatMap(_.get("foo")), Some("bar"))
-      assertEquals(data.dataset.flatMap(_.get("again")), Some("again"))
+      assertEquals(data.attrs.get("foo"), Some("bar"))
+      assertEquals(data.dataset.get("foo"), Some("bar"))
+      assertEquals(data.dataset.get("again"), Some("again"))
 
     }
 
@@ -704,10 +690,10 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     vnode0.test("adds children to parent with no children") { vnode0 =>
-      val vnode1 = h("span", VNodeData.builder.withKey("span").build)
+      val vnode1 = h("span", VNodeData(key = Some("span")))
       val vnode2 = h(
         "span",
-        VNodeData.builder.withKey("span").build,
+        VNodeData(key = Some("span")),
         Array("1", "2", "3").map(spanNum)
       )
       val elm = patch(vnode0, vnode1).elm.get
@@ -722,10 +708,10 @@ class SnabbdomSuite extends BaseSuite {
     vnode0.test("removes all children to parent") { vnode0 =>
       val vnode1 = h(
         "span",
-        VNodeData.builder.withKey("span").build,
+        VNodeData(key = Some("span")),
         Array("1", "2", "3").map(spanNum)
       )
-      val vnode2 = h("span", VNodeData.builder.withKey("span").build)
+      val vnode2 = h("span", VNodeData(key = Some("span")))
       val elm = patch(vnode0, vnode1).elm.get
       assertEquals(
         elm.asInstanceOf[dom.Element].children.toList.map(_.innerHTML),
@@ -736,8 +722,8 @@ class SnabbdomSuite extends BaseSuite {
     }
 
     vnode0.test("update one child with same key but different sel") { vnode0 =>
-      val data = VNodeData.builder.withKey("span").build
-      val data2 = VNodeData.builder.withKey("2").build
+      val data = VNodeData(key = Some("span"))
+      val data2 = VNodeData(key = Some("2"))
       val vnode1 = h("span", data, Array("1", "2", "3").map(spanNum))
       val vnode2 =
         h("span", data, Array(spanNum("1"), h("i", data2, "2"), spanNum("3")))
@@ -947,7 +933,7 @@ class SnabbdomSuite extends BaseSuite {
     def spanNumWithOpacity(n: Int, o: String) = {
       h(
         "span",
-        VNodeData.builder.withKey(n.toString).withStyle("opacity" -> o).build,
+        VNodeData(key = Some(n.toString), style = Map("opacity" -> o)),
         n.toString
       )
     }
@@ -1180,7 +1166,7 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder.withHook(Hooks(create = Some(cb))).build,
+            VNodeData(hook = Some(Hooks(create = Some(cb)))),
             Array(
               h("span", "Child 1"),
               h("span", "Child 2")
@@ -1212,7 +1198,7 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder.withHook(Hooks(insert = Some(cb))).build,
+            VNodeData(hook = Some(Hooks(insert = Some(cb)))),
             Array(
               h("span", "Child 1"),
               h("span", "Child 2")
@@ -1238,7 +1224,7 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder.withHook(Hooks(prepatch = Some(cb))).build,
+            VNodeData(hook = Some(Hooks(prepatch = Some(cb)))),
             Array(
               h("span", "Child 1"),
               h("span", "Child 2")
@@ -1252,7 +1238,7 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder.withHook(Hooks(prepatch = Some(cb))).build,
+            VNodeData(hook = Some(Hooks(prepatch = Some(cb)))),
             Array(
               h("span", "Child 1"),
               h("span", "Child 2")
@@ -1281,14 +1267,14 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder
-              .withHook(
+            VNodeData(hook =
+              Some(
                 Hooks(
                   prepatch = Some((_, _) => preCb()),
                   postpatch = Some((_, _) => postCb())
                 )
               )
-              .build,
+            ),
             Array(
               h("span", "Child 1"),
               h("span", "Child 2")
@@ -1302,14 +1288,14 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder
-              .withHook(
+            VNodeData(hook =
+              Some(
                 Hooks(
                   prepatch = Some((_, _) => preCb()),
                   postpatch = Some((_, _) => postCb())
                 )
               )
-              .build,
+            ),
             Array(
               h("span", "Child 1"),
               h("span", "Child 2")
@@ -1338,16 +1324,12 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder
-              .withHook(Hooks(update = Some(cb(result1, _, _))))
-              .build,
+            VNodeData(hook = Some(Hooks(update = Some(cb(result1, _, _))))),
             Array(
               h("span", "Child 1"),
               h(
                 "span",
-                VNodeData.builder
-                  .withHook(Hooks(update = Some(cb(result2, _, _))))
-                  .build,
+                VNodeData(hook = Some(Hooks(update = Some(cb(result2, _, _))))),
                 "Child 2"
               )
             )
@@ -1360,16 +1342,12 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder
-              .withHook(Hooks(update = Some(cb(result1, _, _))))
-              .build,
+            VNodeData(hook = Some(Hooks(update = Some(cb(result1, _, _))))),
             Array(
               h("span", "Child 1"),
               h(
                 "span",
-                VNodeData.builder
-                  .withHook(Hooks(update = Some(cb(result2, _, _))))
-                  .build,
+                VNodeData(hook = Some(Hooks(update = Some(cb(result2, _, _))))),
                 "Child 2"
               )
             )
@@ -1399,7 +1377,7 @@ class SnabbdomSuite extends BaseSuite {
           h("span", "First sibling"),
           h(
             "div",
-            VNodeData.builder.withHook(Hooks(remove = Some(cb))).build,
+            VNodeData(hook = Some(Hooks(remove = Some(cb)))),
             Array(
               h("span", "Child 1"),
               h("span", "Child 2")
@@ -1425,7 +1403,7 @@ class SnabbdomSuite extends BaseSuite {
         Array(
           h(
             "div",
-            VNodeData.builder.withHook(Hooks(destroy = Some(_ => cb()))).build,
+            VNodeData(hook = Some(Hooks(destroy = Some(_ => cb())))),
             Array(h("span", "Child 1"))
           )
         )
@@ -1448,17 +1426,17 @@ class SnabbdomSuite extends BaseSuite {
       }
       lazy val vnode1 = h(
         "div",
-        VNodeData.builder
-          .withHook(Hooks(init = Some(init), prepatch = Some(prepatch)))
-          .build
+        VNodeData(hook =
+          Some(Hooks(init = Some(init), prepatch = Some(prepatch)))
+        )
       )
       patch(vnode0, vnode1)
       assertEquals(count, 1)
       lazy val vnode2 = h(
         "span",
-        VNodeData.builder
-          .withHook(Hooks(init = Some(init), prepatch = Some(prepatch)))
-          .build
+        VNodeData(hook =
+          Some(Hooks(init = Some(init), prepatch = Some(prepatch)))
+        )
       )
       patch(vnode1, vnode2)
       assertEquals(count, 2)
@@ -1478,9 +1456,7 @@ class SnabbdomSuite extends BaseSuite {
           Array(
             h(
               "a",
-              VNodeData.builder
-                .withHook(Hooks(remove = Some((_, rm) => rm3 = rm)))
-                .build
+              VNodeData(hook = Some(Hooks(remove = Some((_, rm) => rm3 = rm))))
             )
           )
         )
@@ -1508,7 +1484,7 @@ class SnabbdomSuite extends BaseSuite {
       }
       val vnode1 = h(
         "div",
-        VNodeData.builder.withHook(Hooks(remove = Some(cb))).build,
+        VNodeData(hook = Some(Hooks(remove = Some(cb)))),
         Array(
           h("b", "Child 1"),
           h("i", "Child 2")
@@ -1552,7 +1528,7 @@ class SnabbdomSuite extends BaseSuite {
               Array(
                 h(
                   "span",
-                  VNodeData.builder.withHook(Hooks(destroy = Some(cb))).build,
+                  VNodeData(hook = Some(Hooks(destroy = Some(cb)))),
                   "Child 1"
                 ),
                 h("span", "Child 2")
@@ -1672,7 +1648,7 @@ class SnabbdomSuite extends BaseSuite {
         Array(
           h(
             "span",
-            VNodeData.builder.withHook(Hooks(update = Some(cb))).build,
+            VNodeData(hook = Some(Hooks(update = Some(cb)))),
             "Hello"
           ),
           h("span", "there")
@@ -1693,7 +1669,7 @@ class SnabbdomSuite extends BaseSuite {
         Array(
           h(
             "span",
-            VNodeData.builder.withHook(Hooks(update = Some(cb))).build,
+            VNodeData(hook = Some(Hooks(update = Some(cb)))),
             "Hello"
           ),
           h("span", "there")

--- a/snabbdom/src/test/scala/snabbdom/StyleSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/StyleSuite.scala
@@ -69,15 +69,14 @@ class StyleSuite extends BaseSuite {
     vnode0.test("is being styled") { vnode0 =>
       val elm = patch(
         vnode0,
-        h("div", VNodeData.builder.withStyle("fontSize" -> "12px").build)
+        h("div", VNodeData(style = Map("fontSize" -> "12px")))
       ).elm.get.asInstanceOf[dom.HTMLElement]
       assertEquals(elm.style.fontSize, "12px")
     }
 
     vnode0.test("can be memoized") { vnode0 =>
-      val cachedStyles = VNodeData.builder
-        .withStyle("fontSize" -> "14px", "display" -> "inline")
-        .build
+      val cachedStyles =
+        VNodeData(style = Map("fontSize" -> "14px", "display" -> "inline"))
       val vnode1 = h("i", cachedStyles)
       val vnode2 = h("i", cachedStyles)
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
@@ -91,23 +90,17 @@ class StyleSuite extends BaseSuite {
     vnode0.test("updates styles") { vnode0 =>
       val vnode1 = h(
         "i",
-        VNodeData.builder
-          .withStyle("fontSize" -> "14px", "display" -> "inline")
-          .build
+        VNodeData(style = Map("fontSize" -> "14px", "display" -> "inline"))
       )
 
       val vnode2 = h(
         "i",
-        VNodeData.builder
-          .withStyle("fontSize" -> "12px", "display" -> "block")
-          .build
+        VNodeData(style = Map("fontSize" -> "12px", "display" -> "block"))
       )
 
       val vnode3 = h(
         "i",
-        VNodeData.builder
-          .withStyle("fontSize" -> "10px", "display" -> "block")
-          .build
+        VNodeData(style = Map("fontSize" -> "10px", "display" -> "block"))
       )
 
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
@@ -124,11 +117,11 @@ class StyleSuite extends BaseSuite {
 
     vnode0.test("explicitly removes styles") { vnode0 =>
       val vnode1 =
-        h("i", VNodeData.builder.withStyle("fontSize" -> "14px").build)
+        h("i", VNodeData(style = Map("fontSize" -> "14px")))
       val vnode2 =
-        h("i", VNodeData.builder.withStyle("fontSize" -> "").build)
+        h("i", VNodeData(style = Map("fontSize" -> "")))
       val vnode3 =
-        h("i", VNodeData.builder.withStyle("fontSize" -> "10px").build)
+        h("i", VNodeData(style = Map("fontSize" -> "10px")))
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
       assertEquals(elm1.style.fontSize, "14px")
       val elm2 = patch(vnode1, vnode2).elm.get.asInstanceOf[dom.HTMLElement]
@@ -138,11 +131,9 @@ class StyleSuite extends BaseSuite {
     }
 
     vnode0.test("implicitly removes styles from element") { vnode0 =>
-      val vnode1 =
-        h("i", VNodeData.builder.withStyle("fontSize" -> "14px").build)
-      val vnode2 = h("i", VNodeData.empty)
-      val vnode3 =
-        h("i", VNodeData.builder.withStyle("fontSize" -> "10px").build)
+      val vnode1 = h("i", VNodeData(style = Map("fontSize" -> "14px")))
+      val vnode2 = h("i", VNodeData())
+      val vnode3 = h("i", VNodeData(style = Map("fontSize" -> "10px")))
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
       assertEquals(elm1.style.fontSize, "14px")
       val elm2 = patch(vnode1, vnode2).elm.get.asInstanceOf[dom.HTMLElement]
@@ -154,12 +145,9 @@ class StyleSuite extends BaseSuite {
     vnode0.test("updates css variables") { vnode0 =>
       assume(hasCssVariables)
 
-      val vnode1 =
-        h("div", VNodeData.builder.withStyle("--myVar" -> "1").build)
-      val vnode2 =
-        h("div", VNodeData.builder.withStyle("--myVar" -> "2").build)
-      val vnode3 =
-        h("div", VNodeData.builder.withStyle("--myVar" -> "3").build)
+      val vnode1 = h("div", VNodeData(style = Map("--myVar" -> "1")))
+      val vnode2 = h("div", VNodeData(style = Map("--myVar" -> "2")))
+      val vnode3 = h("div", VNodeData(style = Map("--myVar" -> "3")))
 
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
       assertEquals(elm1.style.getPropertyValue("--myVar"), "1")
@@ -173,12 +161,9 @@ class StyleSuite extends BaseSuite {
     vnode0.test("explicitly removes css variables") { vnode0 =>
       assume(hasCssVariables)
 
-      val vnode1 =
-        h("i", VNodeData.builder.withStyle("--myVar" -> "1").build)
-      val vnode2 =
-        h("i", VNodeData.builder.withStyle("--myVar" -> "").build)
-      val vnode3 =
-        h("i", VNodeData.builder.withStyle("--myVar" -> "3").build)
+      val vnode1 = h("i", VNodeData(style = Map("--myVar" -> "1")))
+      val vnode2 = h("i", VNodeData(style = Map("--myVar" -> "")))
+      val vnode3 = h("i", VNodeData(style = Map("--myVar" -> "3")))
 
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]
       assertEquals(elm1.style.getPropertyValue("--myVar"), "1")
@@ -195,14 +180,14 @@ class StyleSuite extends BaseSuite {
       val vnode1 =
         h(
           "div",
-          Array(h("i", VNodeData.builder.withStyle("--myVar" -> "1").build))
+          Array(h("i", VNodeData(style = Map("--myVar" -> "1"))))
         )
       val vnode2 =
-        h("div", Array(h("i", VNodeData.empty)))
+        h("div", Array(h("i", VNodeData())))
       val vnode3 =
         h(
           "div",
-          Array(h("i", VNodeData.builder.withStyle("--myVar" -> "3").build))
+          Array(h("i", VNodeData(style = Map("--myVar" -> "3"))))
         )
 
       val elm1 = patch(vnode0, vnode1).elm.get.asInstanceOf[dom.HTMLElement]

--- a/snabbdom/src/test/scala/snabbdom/SvgSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/SvgSuite.scala
@@ -53,8 +53,8 @@ class SvgSuite extends BaseSuite {
   val patch = init(Seq(Attributes.module))
 
   vnode0.test("removes child svg elements") { vnode0 =>
-    val a = h("svg", VNodeData.empty, Array(h("g"), h("g")))
-    val b = h("svg", VNodeData.empty, Array(h("g")))
+    val a = h("svg", VNodeData(), Array(h("g"), h("g")))
+    val b = h("svg", VNodeData(), Array(h("g")))
     val result = patch(patch(vnode0, a), b).elm.get.asInstanceOf[dom.SVGElement]
     assertEquals(result.childNodes.length, 1)
   }
@@ -64,11 +64,11 @@ class SvgSuite extends BaseSuite {
     val testUrl = "/test"
     val a = h(
       "svg",
-      VNodeData.empty,
+      VNodeData(),
       Array(
         h(
           "use",
-          VNodeData.builder.withAttrs("xlink:href" -> testUrl).build,
+          VNodeData(attrs = Map("xlink:href" -> testUrl)),
           Array[VNode]()
         )
       )
@@ -85,7 +85,7 @@ class SvgSuite extends BaseSuite {
     val testAttrValue = "und"
     val a = h(
       "svg",
-      VNodeData.builder.withAttrs("xml:lang" -> testAttrValue).build,
+      VNodeData(attrs = Map("xml:lang" -> testAttrValue)),
       Array[VNode]()
     )
     val result = patch(vnode0, a).elm.get.asInstanceOf[dom.SVGElement]

--- a/snabbdom/src/test/scala/snabbdom/ThunkSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/ThunkSuite.scala
@@ -69,7 +69,7 @@ class ThunkSuite extends BaseSuite {
     val numberInSpan = (arr: Seq[Any]) => {
       called += 1
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
     val vnode1 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
     val vnode2 = h("div", Array(thunk("span", "num", numberInSpan, Seq(2))))
@@ -86,7 +86,7 @@ class ThunkSuite extends BaseSuite {
       val numberInSpan = (arr: Seq[Any]) => {
         called += 1
         val n = arr(0).asInstanceOf[Int]
-        h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+        h("span", VNodeData(key = Some("num")), s"Number is ${n}")
       }
       val vnode1 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
       val vnode2 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
@@ -101,7 +101,7 @@ class ThunkSuite extends BaseSuite {
     val numberInSpan = (arr: Seq[Any]) => {
       called += 1
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
     val vnode1 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
     val vnode2 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1, 2))))
@@ -116,12 +116,12 @@ class ThunkSuite extends BaseSuite {
     val numberInSpan = (arr: Seq[Any]) => {
       called += 1
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
     val numberInSpan2 = (arr: Seq[Any]) => {
       called += 1
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
     val vnode1 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
     val vnode2 = h("div", Array(thunk("span", "num", numberInSpan2, Seq(1))))
@@ -136,7 +136,7 @@ class ThunkSuite extends BaseSuite {
     val numberInSpan = (arr: Seq[Any]) => {
       called += 1
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
     val vnode1 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
     val vnode2 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
@@ -188,7 +188,7 @@ class ThunkSuite extends BaseSuite {
     val numberInSpan = (arr: Seq[Any]) => {
       called += 1
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
     val vnode1 = thunk("span", "num", numberInSpan, Seq(1))
     val vnode2 = thunk("span", "num", numberInSpan, Seq(1))
@@ -214,12 +214,12 @@ class ThunkSuite extends BaseSuite {
   vnode0.test("can be replaced and removed") { vnode0 =>
     val numberInSpan = (arr: Seq[Any]) => {
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
     val oddEven = (arr: Seq[Any]) => {
       val n = arr(0).asInstanceOf[Int]
       val prefix = if (n % 2 == 0) "Even" else "Odd"
-      h("span", VNodeData.builder.withKey("foo").build, s"${prefix}: ${n}")
+      h("span", VNodeData(key = Some("foo")), s"${prefix}: ${n}")
     }
 
     val vnode1 = h("div", Array(thunk("span", "num", numberInSpan, Seq(1))))
@@ -250,13 +250,13 @@ class ThunkSuite extends BaseSuite {
   vnode0.test("can be replaced and removed when root") { vnode0 =>
     val numberInSpan = (arr: Seq[Any]) => {
       val n = arr(0).asInstanceOf[Int]
-      h("span", VNodeData.builder.withKey("num").build, s"Number is ${n}")
+      h("span", VNodeData(key = Some("num")), s"Number is ${n}")
     }
 
     val oddEven = (arr: Seq[Any]) => {
       val n = arr(0).asInstanceOf[Int]
       val prefix = if (n % 2 == 0) "Even" else "Odd"
-      h("span", VNodeData.builder.withKey("foo").build, s"${prefix}: ${n}")
+      h("span", VNodeData(key = Some("foo")), s"${prefix}: ${n}")
     }
 
     val vnode1 = thunk("span", "num", numberInSpan, Seq(1))
@@ -279,10 +279,10 @@ class ThunkSuite extends BaseSuite {
       val n = arr(0).asInstanceOf[Int]
       h(
         "span",
-        VNodeData.builder
-          .withKey("num")
-          .withHook(Hooks(destroy = Some(destroyHook)))
-          .build,
+        VNodeData(
+          key = Some("num"),
+          hook = Some(Hooks(destroy = Some(destroyHook)))
+        ),
         s"Number is ${n}"
       )
     }
@@ -308,10 +308,10 @@ class ThunkSuite extends BaseSuite {
       val n = arr(0).asInstanceOf[Int]
       h(
         "span",
-        VNodeData.builder
-          .withKey("num")
-          .withHook(Hooks(remove = Some(destroyHook)))
-          .build,
+        VNodeData(
+          key = Some("num"),
+          hook = Some(Hooks(remove = Some(destroyHook)))
+        ),
         s"Number is ${n}"
       )
     }

--- a/snabbdom/src/test/scala/snabbdom/ThunkSuite.scala
+++ b/snabbdom/src/test/scala/snabbdom/ThunkSuite.scala
@@ -59,8 +59,8 @@ class ThunkSuite extends BaseSuite {
     }
     val vnode = thunk("span", "num", numberInSpan, Seq(22))
     assertEquals(vnode.sel, Some("span"))
-    assertEquals(vnode.data.flatMap(_.key), Some("num"))
-    assertEquals(vnode.data.flatMap(_.args), Some(Seq(22)))
+    assertEquals(vnode.data.key, Some("num"))
+    assertEquals(vnode.data.args, Some(Seq(22)))
 
   }
 


### PR DESCRIPTION
This is a bigger change. I think making `VNodeData` a case class already feels much more idiomatic and mutability was in fact not needed. It simplifies the code in many places and gets rid of the awkward builder.