### PR TITLE
Use full checkout for coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,10 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout current branch (fast)
+      - name: Checkout current branch (full)
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Download Java (temurin@8)
         id: download-java-temurin-8

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ThisBuild / githubWorkflowAddedJobs +=
     name = "Generate coverage report",
     scalas = List(scala213),
     javas = githubWorkflowJavaVersions.value.toList,
-    steps = List(WorkflowStep.Checkout)
+    steps = List(WorkflowStep.CheckoutFull)
       ++ WorkflowStep.SetupJava(githubWorkflowJavaVersions.value.toList)
       ++ githubWorkflowGeneratedCacheSteps.value
       ++ List(


### PR DESCRIPTION
Noticed some warnings.
```
->  Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0
```