### PR TITLE
Update to munit 1.0.0-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ ThisBuild / Test / jsEnv := {
 }
 
 lazy val scalajsDomVersion = "2.1.0"
-lazy val munitVersion = "0.7.29"
+lazy val munitVersion = "1.0.0-M5"
 
 lazy val root = tlCrossRootProject.aggregate(snabbdom, examples)
 


### PR DESCRIPTION
- https://github.com/scalameta/munit/pull/529

This fixes the lack of MUnit error-reporting, but only for the JSDOM environment which we are currently using for scoverage.

We could make JSDOM the default test environment for local development. In theory this could make debugging failed tests easier, although that should be weighed against the possibility that JSDOM isn't always a faithful representation of browser APIs e.g.
https://github.com/buntec/scala-js-snabbdom/blob/21499a52ec5f16acf29eb0a3837cb5ad929625ee/snabbdom/src/test/scala/snabbdom/ThunkSuite.scala#L176-L180